### PR TITLE
Fix quantity validation and restore rfq_sender module

### DIFF
--- a/scripts/email/rfq_sender.py
+++ b/scripts/email/rfq_sender.py
@@ -140,37 +140,20 @@ def validate_args(args: argparse.Namespace) -> Tuple[bool, Optional[str]]:
     if not os.path.exists(args.file_location):
         return False, f"File location '{args.file_location}' does not exist"
 
-    # Validate quantities format
-    try:
-        # Handle potential mixed types by ensuring string conversion first
-        if not isinstance(args.quantities, str):
-            args.quantities = str(args.quantities)
-            
-        # Clean up the input - remove any non-numeric characters except commas
-        cleaned_quantities = []
-        for q in args.quantities.split(","):
-            q = q.strip()
-            # Skip empty parts
-            if not q:
-                continue
-            try:
-                # Try to convert to integer
-                qty = int(q)
-                if qty > 0:
-                    cleaned_quantities.append(qty)
-            except ValueError:
-                # If conversion fails, log a warning but don't fail validation
-                logger.warning(f"Non-integer quantity value found: '{q}', skipping")
-                
-        if not cleaned_quantities:
-            return False, "Quantities list cannot be empty or contains only invalid values"
-            
-        # Store the cleaned quantities back in args for later use
-        args.cleaned_quantities = cleaned_quantities
-    except Exception as e:
-        logger.error(f"Error processing quantities '{args.quantities}': {str(e)}")
-        return False, f"Error processing quantities: {str(e)}"
+    # Validate quantities
+    if not args.quantities or not str(args.quantities).strip():
+        return False, "Quantities must be comma-separated integers"
 
+    try:
+        quantities = [int(q.strip()) for q in str(args.quantities).split(",")]
+    except ValueError:
+        return False, "Quantities must be comma-separated integers"
+
+    if any(q <= 0 for q in quantities):
+        return False, "Quantities must be positive integers"
+
+    # Store parsed quantities for later use
+    args.cleaned_quantities = quantities
     return True, None
 
 

--- a/scripts/rfq_sender.py
+++ b/scripts/rfq_sender.py
@@ -1,0 +1,40 @@
+"""Convenience wrapper for :mod:`scripts.email.rfq_sender`.
+
+The original RFQ sender implementation lives in ``scripts/email/rfq_sender.py``.
+Historically tests and other tooling imported it as ``scripts/rfq_sender``.  At
+some point the file was moved into the ``email`` package which left the old
+import path broken.  This lightweight module loads the real implementation and
+re-exports the functions that are relied upon by the tests and other modules.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from types import ModuleType
+
+# Locate the real rfq_sender implementation
+_module_path = os.path.join(os.path.dirname(__file__), "email", "rfq_sender.py")
+_spec = importlib.util.spec_from_file_location("_rfq_sender", _module_path)
+_rfq: ModuleType = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader  # for type checkers
+_spec.loader.exec_module(_rfq)
+
+# Re-export commonly used attributes
+logger = _rfq.logger
+parse_args = _rfq.parse_args
+validate_args = _rfq.validate_args
+get_attachments = _rfq.get_attachments
+render_template = _rfq.render_template
+validate_email = _rfq.validate_email
+check_attachments = _rfq.check_attachments
+
+__all__ = [
+    "logger",
+    "parse_args",
+    "validate_args",
+    "get_attachments",
+    "render_template",
+    "validate_email",
+    "check_attachments",
+]


### PR DESCRIPTION
## Summary
- fix quantity validation to reject non-numeric and non-positive values
- provide wrapper module so `scripts/rfq_sender` remains importable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965d67e890832bae42c0c0b4d9c5dd