### PR TITLE
chore: remove unused typing import

### DIFF
--- a/cli/utils/validator_cli.py
+++ b/cli/utils/validator_cli.py
@@ -2,7 +2,6 @@ import questionary
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from typing import List
 
 from core.validation.validator import SpecValidator
 


### PR DESCRIPTION
## Summary
- remove unused typing import from validator CLI

## Testing
- `flake8 cli/utils/validator_cli.py` *(fails: line too long, no newline at EOF)*
- `pytest -q` *(fails: streamlit.errors.StreamlitSecretNotFoundError: No secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08c2f0808832b86332624f38e006a