### PR TITLE
Remove attachment parameter from email drafts

### DIFF
--- a/core/email/email_manager.py
+++ b/core/email/email_manager.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 import jinja2
 import logging
-from typing import Dict, List, Optional, Tuple, Any, Mapping, Union
+from typing import Dict, Optional, Tuple, Any
 from dotenv import load_dotenv
 from core.secrets import get_section  # to grab [company] and [app]
 from core.email.utils import extract_rfq_fields
@@ -130,12 +130,14 @@ class EmailManager:
         recipient: str,
         subject: str,
         body: str,
-        attachments: List[str] = None,
         html_format: bool = True,
         cc_email: str = None,
     ) -> bool:
         """
         Create a draft email using Microsoft Graph only.
+
+        Attachments are not supported. Files should be uploaded to Box and
+        shared via link in the email body.
         """
         try:
             # Pull mailbox + default CC from secrets
@@ -159,10 +161,6 @@ class EmailManager:
                 cc=[cc] if cc else None,
             )
 
-            # Attachments are deprecated and ignored — all files must be shared via Box links in the email body.
-            if attachments:
-                logger.info("Attachments provided to create_draft_email are ignored by policy; use Box upload + shared link instead.")
-
             return True
         except Exception as e:
             logger.error(f"Graph draft creation failed for {recipient}: {e}")
@@ -173,15 +171,18 @@ class EmailManager:
         recipient: str,
         subject: str,
         body: str,
-        attachments: List[str] = None,
     ) -> bool:
+        """Convenience wrapper around :meth:`create_draft_email`.
+
+        Attachments are not supported; include file links in the email body
+        instead.
+        """
         try:
             cc_email = self.exchange_settings.get('cc', None)
             success = self.create_draft_email(
                 recipient=recipient,
                 subject=subject,
                 body=body,
-                attachments=attachments,
                 cc_email=cc_email,
                 html_format=True,
             )
@@ -258,7 +259,7 @@ class EmailManager:
                         continue
                     
                     # Send email
-                    if self.send_email(recipient_email, subject, body, attachments=None):
+                    if self.send_email(recipient_email, subject, body):
                         successful += 1
             
             return successful, total

--- a/streamlit_app/pages/07_email_and_box_settings.py
+++ b/streamlit_app/pages/07_email_and_box_settings.py
@@ -562,14 +562,16 @@ def create_email_body(queue_items: pd.DataFrame,
         return f"<p>{greeting}</p><p>Please see the RFQ details below.</p>"
 
 
-def create_draft_email(recipient: str, 
-                      subject: str, 
-                      body: str, 
-                      attachments: List[str] = None,
+def create_draft_email(recipient: str,
+                      subject: str,
+                      body: str,
                       cc: List[str] = None,
                       exchange_settings: Dict[str, Any] = None) -> bool:
     """
     Create a draft email using Microsoft Graph (no EWS).
+
+    Attachments are not supported; upload files to Box and include a
+    share link in the message body instead.
     """
     try:
         # Graph-only: pull user UPN/CC from secrets
@@ -579,7 +581,6 @@ def create_draft_email(recipient: str,
             recipient=recipient,
             subject=subject,
             body=body,
-            attachments=attachments,
             cc_email=(cc[0] if isinstance(cc, list) and cc else ex_cfg.get("cc")),
             html_format=True,
         )
@@ -1134,12 +1135,11 @@ def display_queue_for_emails(user: Dict[str, Any], role: str):
                                         # Inject Box link into the email body
                                         body_with_link = inject_box_link_into_body(body, share_link, is_cui)
 
-                                        # Create the main draft (no attachments; link in body)
+                                        # Create the main draft with the Box link in the body
                                         if create_draft_email(
                                             recipient=vendor_email,
                                             subject=subject,
                                             body=body_with_link,
-                                            attachments=None,
                                             cc=[exchange_settings.get('cc')] if exchange_settings.get('cc') else None,
                                             exchange_settings=exchange_settings
                                         ):
@@ -1158,7 +1158,6 @@ def display_queue_for_emails(user: Dict[str, Any], role: str):
                                                     recipient=vendor_email,
                                                     subject=pwd_subject,
                                                     body=pwd_body,
-                                                    attachments=None,
                                                     cc=[exchange_settings.get('cc')] if exchange_settings.get('cc') else None,
                                                     exchange_settings=exchange_settings
                                                 ):
@@ -1490,12 +1489,11 @@ def display_queue_for_emails(user: Dict[str, Any], role: str):
                                         # Inject Box link into the email body
                                         body_with_link = inject_box_link_into_body(body, share_link, is_cui)
 
-                                        # Create the main draft (no attachments; link in body)
+                                        # Create the main draft with the Box link in the body
                                         if create_draft_email(
                                             recipient=vendor_email,
                                             subject=subject,
                                             body=body_with_link,
-                                            attachments=None,
                                             cc=[exchange_settings.get('cc')] if exchange_settings.get('cc') else None,
                                             exchange_settings=exchange_settings
                                         ):
@@ -1514,7 +1512,6 @@ def display_queue_for_emails(user: Dict[str, Any], role: str):
                                                     recipient=vendor_email,
                                                     subject=pwd_subject,
                                                     body=pwd_body,
-                                                    attachments=None,
                                                     cc=[exchange_settings.get('cc')] if exchange_settings.get('cc') else None,
                                                     exchange_settings=exchange_settings
                                                 ):


### PR DESCRIPTION
## Summary
- drop unused `attachments` parameter from `EmailManager.create_draft_email` and `EmailManager.send_email`
- adjust Streamlit email helper to match new signature and clarify that attachments must be shared via Box links

## Testing
- `pytest` *(fails: StreamlitSecretNotFoundError: No secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0960d30e8832b9ce818d9de225b28