### PR TITLE
Raise error on unsupported email attachments

### DIFF
--- a/core/email/email_manager.py
+++ b/core/email/email_manager.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 import jinja2
 import logging
-from typing import Dict, Optional, Tuple, Any
+from typing import Dict, Optional, Tuple, Any, List
 from dotenv import load_dotenv
 from core.secrets import get_section  # to grab [company] and [app]
 from core.email.utils import extract_rfq_fields
@@ -130,6 +130,7 @@ class EmailManager:
         recipient: str,
         subject: str,
         body: str,
+        attachments: Optional[List[str]] = None,
         html_format: bool = True,
         cc_email: str = None,
     ) -> bool:
@@ -138,8 +139,13 @@ class EmailManager:
 
         Attachments are not supported. Files should be uploaded to Box and
         shared via link in the email body.
+        If any attachments are provided, a ValueError is raised.
         """
         try:
+            if attachments:
+                raise ValueError(
+                    "Attachments are not supported; upload files to Box and include links instead."
+                )
             # Pull mailbox + default CC from secrets
             ex_cfg = get_section("exchange")
             user_upn = ex_cfg.get("username", "")

--- a/scripts/box/test_email_with_box.py
+++ b/scripts/box/test_email_with_box.py
@@ -2,7 +2,7 @@
 Test Email with Box Integration Script
 
 This script tests the email functionality with Box integration by creating a draft email
-with attachments, which will be uploaded to Box instead of being attached directly.
+that assumes large files are shared via Box links instead of being attached directly.
 
 Usage:
     python scripts\test_email_with_box.py
@@ -62,30 +62,8 @@ def main() -> None:
         <p>Large attachments should be uploaded to Box and a share link should be included in this email.</p>
         """
         
-        # Find some test files to attach
-        test_files = []
-        docs_dir = os.path.join(project_root, "docs")
-        
-        # Look for files larger than 1MB
-        for root, _, files in os.walk(docs_dir):
-            for file in files:
-                file_path = os.path.join(root, file)
-                if os.path.isfile(file_path):
-                    file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
-                    if file_size_mb > 1.0:
-                        test_files.append(file_path)
-                        logger.info(f"Found test file: {file_path} ({file_size_mb:.2f} MB)")
-                        if len(test_files) >= 3:  # Limit to 3 files
-                            break
-            if len(test_files) >= 3:
-                break
-                
-        if not test_files:
-            logger.error("No test files found")
-            sys.exit(1)
-        
-        # Create draft email with attachments
-        logger.info(f"Creating draft email with {len(test_files)} attachments")
+        # Create draft email (no attachments; files should be shared via Box links)
+        logger.info("Creating draft email without attachments")
         
         # Generate a unique quote_id and process for the test
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -97,7 +75,6 @@ def main() -> None:
             recipient=to_email,
             subject=subject,
             body=body,
-            attachments=test_files,
             logger=logger,
             html_format=True,
             use_outlook_signature=False,

--- a/scripts/box/test_email_with_hybrid_structure.py
+++ b/scripts/box/test_email_with_hybrid_structure.py
@@ -2,7 +2,7 @@
 Test Email with Hybrid Box Structure Script
 
 This script tests the email functionality with the new hybrid Box folder structure by creating
-a draft email with attachments, which will be organized in the hybrid folder structure.
+a draft email that assumes files are shared via Box links rather than being attached directly.
 
 Usage:
     python scripts\box\test_email_with_hybrid_structure.py
@@ -109,22 +109,14 @@ def main() -> None:
         logger.info(f"  Part numbers: {part_numbers}")
         
         # Create test files
-        logger.info("Creating test files")
-        test_files = create_test_files(test_dir, part_numbers)
-        
-        logger.info(f"Created {len(test_files)} test files")
-        for file_path in test_files:
-            logger.info(f"  {file_path}")
-        
-        # Create draft email with attachments
-        logger.info(f"Creating draft email with {len(test_files)} attachments")
+        # Create draft email (no attachments; files should be shared via Box links)
+        logger.info("Creating draft email without attachments")
         
         success = create_draft_email(
             outlook=outlook,
             recipient=to_email,
             subject=subject,
             body=body,
-            attachments=test_files,
             logger=logger,
             html_format=True,
             use_outlook_signature=False,

--- a/scripts/mail/email_from_list.py
+++ b/scripts/mail/email_from_list.py
@@ -695,7 +695,7 @@ def create_draft_email(
         recipient: str,
         subject: str,
         body: str,
-        attachments: List[str],
+        attachments: List[str] = None,
         logger: logging.Logger = None,
         html_format: bool = True,
         use_outlook_signature: bool = True,
@@ -711,7 +711,7 @@ def create_draft_email(
         recipient: Email address of the recipient
         subject: Email subject
         body: Email body (HTML or plain text)
-        attachments: List of file paths to attach
+        attachments: List of file paths to attach (unsupported)
         logger: Optional logger for logging messages
         html_format: Whether the body is HTML (True) or plain text (False)
         use_outlook_signature: Whether to use Outlook's general signature
@@ -749,28 +749,13 @@ def create_draft_email(
             mail.BodyFormat = 1  # 1 = olFormatPlain
             mail.Body = body
 
-        # Track missing attachments and files for Box
+        if attachments:
+            raise ValueError(
+                "Attachments are not supported; upload files to Box and include links instead."
+            )
         missing_attachments = []
         files_for_box = []
         box_files_info = []  # To store information about files uploaded to Box
-
-        # Collect valid files for Box upload
-        for path in attachments:
-            if not os.path.isfile(path):
-                if logger:
-                    logger.warning(f"Missing attachment: {path}")
-                else:
-                    print(f"Missing attachment: {path}")
-                missing_attachments.append(path)
-                continue
-
-            # Add file to Box upload list
-            files_for_box.append(path)
-            file_size_mb = os.path.getsize(path) / (1024 * 1024)
-            if logger:
-                logger.info(f"File will be uploaded to Box: {path} ({file_size_mb:.2f} MB)")
-            else:
-                print(f"File will be uploaded to Box: {path} ({file_size_mb:.2f} MB)")
 
         # Upload files to Box
         box_share_link = None
@@ -1529,38 +1514,30 @@ def process_queue(
                             else:
                                 print(f"Path not found: {file_path}")
 
-                if not attachments:
-                    if logger:
-                        logger.warning(f"No valid attachments found for quote {quote_id}, process {process}")
-                    else:
-                        print(f"No valid attachments found for quote {quote_id}, process {process}")
-
-                # Build email with actual attachment count
+                # Build email body
                 subject, body = create_email_body(
-                    info, 
-                    process_items, 
+                    info,
+                    process_items,
                     process=process,
                     use_template=use_template,
                     template_path=template_path,
                     sample_table_path=sample_table_path,
                     signature=signature,
                     html_format=True,
-                    actual_attachments=attachments
                 )
 
                 # Create draft
                 success = create_draft_email(
-                    outlook,
-                    recipient,
-                    subject,
-                    body,
-                    attachments,
-                    logger,
+                    outlook=outlook,
+                    recipient=recipient,
+                    subject=subject,
+                    body=body,
+                    logger=logger,
                     html_format=True,
                     use_outlook_signature=False,
                     quote_id=quote_id,
                     process=process,
-                    signature=signature
+                    signature=signature,
                 )
 
                 if success:

--- a/utils/rfq_email.py
+++ b/utils/rfq_email.py
@@ -226,7 +226,7 @@ def create_draft_email(
         recipient: Email address of the recipient
         subject: Email subject
         body: Email body (HTML or plain text)
-        attachments: List of file paths to attach
+        attachments: List of file paths to attach (unsupported)
         html_format: Whether the body is HTML (True) or plain text (False)
         use_outlook_signature: Ignored in Exchange implementation
         cc_email: Optional CC email address
@@ -235,6 +235,11 @@ def create_draft_email(
         True if successful, False otherwise
     """
     try:
+        if attachments:
+            raise ValueError(
+                "Attachments are not supported; upload files to Box and include links instead."
+            )
+
         # Create message
         m = Message(
             account=account,
@@ -244,26 +249,11 @@ def create_draft_email(
             body_type='HTML' if html_format else 'Text',
             to_recipients=[Mailbox(email_address=recipient)]
         )
-        
+
         # Add CC if specified
         if cc_email:
             m.cc_recipients = [Mailbox(email_address=cc_email)]
-        
-        # Add attachments
-        if attachments:
-            for file_path in attachments:
-                if os.path.exists(file_path):
-                    with open(file_path, 'rb') as f:
-                        content = f.read()
-                    
-                    file_attachment = FileAttachment(
-                        name=os.path.basename(file_path),
-                        content=content
-                    )
-                    m.attach(file_attachment)
-                else:
-                    logger.warning(f"Missing attachment: {file_path}")
-        
+
         # Save the draft
         m.save()
         
@@ -288,7 +278,7 @@ def send_email(
         subject: Email subject
         body: Email body (HTML)
         exchange_settings: Dictionary with Exchange settings (uses config if None)
-        attachments: List of file paths to attach
+        attachments: List of file paths to attach (unsupported)
         
     Returns:
         True if draft created successfully, False otherwise
@@ -304,13 +294,17 @@ def send_email(
         # Get CC email if specified
         cc_email = exchange_settings.get('cc', get_section("exchange").get('cc'))
         
+        if attachments:
+            raise ValueError(
+                "Attachments are not supported; upload files to Box and include links instead."
+            )
+
         # Create draft email
         success = create_draft_email(
             account=account,
             recipient=recipient,
             subject=subject,
             body=body,
-            attachments=attachments,
             cc_email=cc_email,
             html_format=True
         )
@@ -405,7 +399,7 @@ def process_queue_and_send_emails(
             )
 
             # Send email
-            if send_email(recipient_email, subject, body, exchange_settings, attachments=None):
+            if send_email(recipient_email, subject, body, exchange_settings):
                 successful += 1
 
     return successful, total


### PR DESCRIPTION
## Summary
- refuse to draft emails when attachments are provided
- adjust legacy email utilities and demo scripts to drop attachment usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c09997f1a8832ba01ffbe58568c8ff