### PR TITLE
Add fallback for Box spec ID retrieval

### DIFF
--- a/utils/specs.py
+++ b/utils/specs.py
@@ -10,6 +10,12 @@ _box_spec_id = (
     os.environ.get("BOX_FAMILIAR_SPECS_FILE_ID", "").strip()
     or os.environ.get("BOX_BOX_FAMILIAR_SPECS_FILE_ID", "").strip()
 )
+if not _box_spec_id:
+    from core.secrets import get_section
+
+    _box_spec_id = (
+        str(get_section("box").get("BOX_FAMILIAR_SPECS_FILE_ID", "")).strip()
+    )
 spec_manager = SpecManager(Paths.SPECS_PATH, box_file_id=_box_spec_id or None)
 
 


### PR DESCRIPTION
## Summary
- fall back to `core.secrets.get_section` when Box spec ID env vars are missing
- ensure `SpecManager` receives `box_file_id` only when available

## Testing
- `pytest -q` *(fails: StreamlitSecretNotFoundError: No secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aad3d14c832ba2c1fb6d9c1b81a8