### PR TITLE
Handle missing FamiliarSpecs in Streamlit pages

### DIFF
--- a/streamlit_app/pages/04_queue_management.py
+++ b/streamlit_app/pages/04_queue_management.py
@@ -39,26 +39,32 @@ def setup_page():
 def display_add_to_queue_form(user):
     """Display the form for adding a part to the queue."""
     processes = load_process_list()
-    
+    if not processes:
+        st.error("FamiliarSpecs.csv not found in Box or local path.")
+        return
+
     # Process selection outside the form
     st.subheader("Select Process and Spec")
     selected_process = st.selectbox(
-        "Process", 
-        options=sorted(processes), 
+        "Process",
+        options=sorted(processes),
         help="Select the manufacturing process"
     )
-    
+
     # Load specs based on selected process (guard against None/empty)
     if selected_process:
         available_specs = load_specs_for_process(selected_process)
+        if not available_specs:
+            st.error("FamiliarSpecs.csv not found in Box or local path.")
+            return
     else:
         available_specs = []
     spec = st.selectbox(
-        "Spec (optional)", 
-        options=available_specs, 
+        "Spec (optional)",
+        options=available_specs,
         help="Select the specification if applicable"
     )
-    
+
     st.subheader("Part Details")
     with st.form("rfq_form"):
         col1, col2 = st.columns(2)

--- a/streamlit_app/pages/05_specifications_management.py
+++ b/streamlit_app/pages/05_specifications_management.py
@@ -45,6 +45,9 @@ def display_add_spec_form(user, role):
     
     # Get existing processes and issuers for dropdowns
     processes = load_process_list()
+    if not processes:
+        st.error("FamiliarSpecs.csv not found in Box or local path.")
+        return
     issuers = load_issuers()
     
     with st.form("add_spec_form"):
@@ -169,7 +172,11 @@ def display_specs_data(user, role):
         
         with col1:
             # Filter by process
-            processes = ["All"] + sorted(load_process_list())
+            process_list = load_process_list()
+            if not process_list:
+                st.error("FamiliarSpecs.csv not found in Box or local path.")
+                return
+            processes = ["All"] + sorted(process_list)
             process_filter = st.selectbox("Filter by Process", processes)
         
         with col2:

--- a/streamlit_app/pages/06_vendors.py
+++ b/streamlit_app/pages/06_vendors.py
@@ -250,9 +250,9 @@ def search_vendors_by_spec():
     # Get all processes
     processes = load_process_list()
 
-    # If no processes are available, guide the user and exit early
+    # If processes list is empty, show error and exit early
     if not processes:
-        st.info("No processes are available. Add specifications in the Specifications page first.")
+        st.error("FamiliarSpecs.csv not found in Box or local path.")
         return
     
     # Create a selectbox for choosing a process
@@ -265,12 +265,12 @@ def search_vendors_by_spec():
     # Get specs for the selected process (guard against None/empty)
     if selected_process:
         specs = load_specs_for_process(selected_process)
+        if not specs:
+            st.error("FamiliarSpecs.csv not found in Box or local path.")
+            return
     else:
         specs = []
-    
-    if not specs:
-        st.warning("No specifications found for the selected process.")
-        return
+
     
     # Create a selectbox for choosing a spec
     selected_spec = st.selectbox("Select Specification", options=sorted(specs))


### PR DESCRIPTION
## Summary
- Halt Queue Management page when FamiliarSpecs.csv is missing
- Guard Specifications Management and Vendors pages from missing FamiliarSpecs.csv data

## Testing
- `pytest` *(fails: streamlit.errors.StreamlitSecretNotFoundError: No secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aad66a28832ba1a6d190b75781ef