### PR TITLE
Surface spec load failures in Streamlit UI

### DIFF
--- a/core/specs/spec_manager.py
+++ b/core/specs/spec_manager.py
@@ -42,33 +42,52 @@ class SpecManager:
             self.box_file_id = box_file_id or None
         else:
             self.box_file_id = (env_id if specs_path is None else None)
+
+        # Store the most recent reason for failing to load specs
+        self.last_load_reason: Optional[str] = None
     
     def _load_from_box(self) -> Optional[pd.DataFrame]:
         """Attempt to load familiar specs CSV from Box if configured.
-        
+
         Returns:
             DataFrame if successful, else None.
         """
+        logger = logging.getLogger(__name__)
+        if not self.box_file_id:
+            msg = "Box file ID not configured; skipping Box load."
+            logger.warning(msg)
+            self.last_load_reason = msg
+            return None
         try:
-            if not self.box_file_id:
-                return None
             # Lazy import to avoid hard dependency
             from scripts.box.box_integration import BoxIntegration
             box = BoxIntegration()
             client = getattr(box, "client", None)
             if not client:
+                msg = "Box client not available; cannot load familiar specs."
+                logger.warning(msg)
+                self.last_load_reason = msg
                 return None
             file_obj = client.file(self.box_file_id)
-            content: bytes = file_obj.content()
+            try:
+                content: bytes = file_obj.content()
+            except Exception as e:
+                msg = f"Failed to fetch familiar specs from Box: {e}"
+                logger.warning(msg)
+                self.last_load_reason = msg
+                return None
             from io import BytesIO
             df = pd.read_csv(BytesIO(content))
             df.columns = df.columns.str.strip().str.lower()
+            self.last_load_reason = None
             return df
         except Exception as e:
+            msg = f"Failed to load familiar specs from Box: {e}"
             try:
-                logging.getLogger(__name__).exception("Failed to load familiar specs from Box")
+                logger.exception(msg)
             except Exception:
                 pass
+            self.last_load_reason = msg
             return None
     
     def _save_to_box(self, df: pd.DataFrame) -> bool:
@@ -110,14 +129,25 @@ class SpecManager:
         box_df = self._load_from_box()
         if isinstance(box_df, pd.DataFrame):
             return box_df
-        
+
         # Fallback to local file
         if not os.path.exists(self.specs_path):
+            msg = f"Local familiar specs file not found: {self.specs_path}"
+            logging.getLogger(__name__).warning(msg)
+            if not self.last_load_reason:
+                self.last_load_reason = msg
             return pd.DataFrame(columns=["process", "spec", "issuer", "notes"])
-            
-        df = pd.read_csv(self.specs_path)
-        df.columns = df.columns.str.strip().str.lower()  # Normalize headers
-        return df
+
+        try:
+            df = pd.read_csv(self.specs_path)
+            df.columns = df.columns.str.strip().str.lower()  # Normalize headers
+            self.last_load_reason = None
+            return df
+        except Exception as e:
+            msg = f"Failed to load familiar specs from local file: {e}"
+            logging.getLogger(__name__).error(msg)
+            self.last_load_reason = msg
+            return pd.DataFrame(columns=["process", "spec", "issuer", "notes"])
     
     def load_process_list(self) -> List[str]:
         """

--- a/streamlit_app/pages/05_specifications_management.py
+++ b/streamlit_app/pages/05_specifications_management.py
@@ -11,12 +11,13 @@ if str(parent_dir) not in sys.path:
 
 # Import utility functions
 from utils.specs import (
-    load_process_list, 
-    load_issuers, 
-    add_spec_entry, 
+    load_process_list,
+    load_issuers,
+    add_spec_entry,
     spec_exists,
     load_familiar_specs,
-    SPECS_PATH
+    SPECS_PATH,
+    get_last_load_reason,
 )
 from streamlit_app.utils.auth_shim import get_user_role
 from streamlit_app.utils.auth_middleware import require_authentication
@@ -46,7 +47,8 @@ def display_add_spec_form(user, role):
     # Get existing processes and issuers for dropdowns
     processes = load_process_list()
     if not processes:
-        st.error("FamiliarSpecs.csv not found in Box or local path.")
+        reason = get_last_load_reason()
+        st.error(reason or "FamiliarSpecs.csv not found in Box or local path.")
         return
     issuers = load_issuers()
     
@@ -138,19 +140,23 @@ def display_current_specs():
     try:
         # Load the specs dataframe (Box-aware)
         df = load_familiar_specs()
-        
-        if not df.empty:
-            st.subheader("Recently Added Specifications")
-            
-            # Sort by most recently added (assuming the CSV is appended to)
-            df = df.tail(5).sort_index(ascending=False)
-            
-            # Display the dataframe
-            st.dataframe(
-                df,
-                width="stretch",
-                hide_index=True
-            )
+
+        if df.empty:
+            reason = get_last_load_reason()
+            st.warning(reason or "No familiar specifications available.")
+            return
+
+        st.subheader("Recently Added Specifications")
+
+        # Sort by most recently added (assuming the CSV is appended to)
+        df = df.tail(5).sort_index(ascending=False)
+
+        # Display the dataframe
+        st.dataframe(
+            df,
+            width="stretch",
+            hide_index=True
+        )
         
     except Exception as e:
         st.error(f"Error loading specifications: {str(e)}")
@@ -161,9 +167,12 @@ def display_specs_data(user, role):
     try:
         # Load specs data
         df = load_familiar_specs()
-        
+
         if df.empty:
-            st.info("No specifications found in the database. Add specs using the 'Add Specification' tab.")
+            reason = get_last_load_reason()
+            st.info(
+                reason or "No specifications found in the database. Add specs using the 'Add Specification' tab."
+            )
             return
         
         # Add filter options
@@ -174,7 +183,8 @@ def display_specs_data(user, role):
             # Filter by process
             process_list = load_process_list()
             if not process_list:
-                st.error("FamiliarSpecs.csv not found in Box or local path.")
+                reason = get_last_load_reason()
+                st.error(reason or "FamiliarSpecs.csv not found in Box or local path.")
                 return
             processes = ["All"] + sorted(process_list)
             process_filter = st.selectbox("Filter by Process", processes)

--- a/utils/specs.py
+++ b/utils/specs.py
@@ -28,6 +28,11 @@ def load_familiar_specs():
     return spec_manager.load_familiar_specs()
 
 
+def get_last_load_reason() -> Optional[str]:
+    """Return the last reason why loading familiar specs failed, if any."""
+    return spec_manager.last_load_reason
+
+
 def load_process_list() -> List[str]:
     """Return a list of unique process names from familiar specs.
 


### PR DESCRIPTION
## Summary
- Warn when Box spec file is missing or Box client is unavailable
- Expose load failure reasons from `SpecManager` and show them in Streamlit spec pages
- Add helper for retrieving spec load failure message

## Testing
- `pytest` *(fails: StreamlitSecretNotFoundError: No secrets found. Valid paths for a secrets.toml file or secret directories are: /root/.streamlit/secrets.toml, /workspace/rfq-sender/.streamlit/secrets.toml)*


------
https://chatgpt.com/codex/tasks/task_e_68c0ada9f01c832b8fdfb83f2cde8d93