### PR TITLE
Add vendors page and global Nav bar

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routers import auth, queue, specs
+from api.routers import auth, queue, specs, vendors
 
 app = FastAPI(title="RFQ Sender API", version="1.0.0")
 
@@ -40,6 +40,7 @@ app.add_middleware(
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(queue.router, prefix="/queue", tags=["queue"])
 app.include_router(specs.router, prefix="/specs", tags=["specs"])
+app.include_router(vendors.router, prefix="/vendors", tags=["vendors"])
 
 
 @app.get("/health")

--- a/api/models/vendor.py
+++ b/api/models/vendor.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ContactOut(BaseModel):
+    name: str = ""
+    first_name: str = ""
+    last_name: str = ""
+    email: str = ""
+    phone: str = ""
+    primary: bool = False
+    state: str = ""
+    website: str = ""
+
+
+class VendorSummary(BaseModel):
+    """Lightweight shape for the list view — no contacts or approvals."""
+    name: str
+    processes: list[str] = []
+    active: bool = True
+    rating: int = 0
+    primary_contact: Optional[ContactOut] = None
+
+
+class VendorDetail(VendorSummary):
+    """Full shape for the detail panel."""
+    id: str = ""
+    notes: str = ""
+    address: dict = {}
+    contacts: list[ContactOut] = []
+    # { "Anodize": ["AMS 2468", "AMS 2469"], ... }
+    approvals: dict[str, list[str]] = {}

--- a/api/routers/vendors.py
+++ b/api/routers/vendors.py
@@ -1,0 +1,106 @@
+"""
+Vendor routes.
+
+GET /vendors/                          — all vendors (summary list)
+GET /vendors/{name}                    — full detail: contacts + approvals
+GET /vendors/search?process=X&spec=Y  — vendors approved for a process/spec
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from typing import Optional
+
+from api.deps import get_current_user
+from api.models.vendor import ContactOut, VendorDetail, VendorSummary
+from core.vendors.vendor_manager import VendorManager
+
+router = APIRouter()
+
+# One shared instance per process lifetime — VendorManager loads files once.
+# If the underlying YAML/JSON changes on disk, call vendor_manager.reload_vendors().
+_vm = VendorManager()
+
+
+def _contact_to_out(c) -> ContactOut:
+    """Convert a Contact dataclass to a Pydantic ContactOut."""
+    return ContactOut(
+        name=c.name,
+        first_name=c.first_name,
+        last_name=c.last_name,
+        email=c.email,
+        phone=c.phone,
+        primary=c.primary,
+        state=c.state,
+        website=c.website,
+    )
+
+
+@router.get("/", response_model=list[VendorSummary])
+def list_vendors(user: dict = Depends(get_current_user)):
+    """
+    Returns all vendors with a summary and their primary contact.
+    The frontend uses this to populate the vendor list.
+    """
+    out = []
+    for v in _vm.vendors:
+        primary = _vm.get_primary_contact(v)
+        out.append(VendorSummary(
+            name=v.name,
+            processes=sorted(v.processes),
+            active=v.active,
+            rating=v.rating,
+            primary_contact=_contact_to_out(primary) if primary else None,
+        ))
+    return sorted(out, key=lambda v: v.name)
+
+
+@router.get("/search", response_model=list[VendorSummary])
+def search_vendors(
+    process: str,
+    spec: Optional[str] = None,
+    user: dict = Depends(get_current_user),
+):
+    """
+    Returns vendors approved for a given process (and optional spec).
+    Powers the "Find by Spec" tab on the frontend.
+
+    Note: this route is defined BEFORE /{name} so FastAPI matches
+    /vendors/search?... before treating "search" as a vendor name.
+    """
+    matches = _vm.find_vendors_for_process_and_spec(process, spec)
+    out = []
+    for v in matches:
+        primary = _vm.get_primary_contact(v)
+        out.append(VendorSummary(
+            name=v.name,
+            processes=sorted(v.processes),
+            active=v.active,
+            rating=v.rating,
+            primary_contact=_contact_to_out(primary) if primary else None,
+        ))
+    return out
+
+
+@router.get("/{name}", response_model=VendorDetail)
+def get_vendor(name: str, user: dict = Depends(get_current_user)):
+    """
+    Returns full detail for one vendor: all contacts + all approved specs.
+    Called when the user clicks a vendor in the list.
+    """
+    vendor = next((v for v in _vm.vendors if v.name == name), None)
+    if not vendor:
+        raise HTTPException(status_code=404, detail=f"Vendor '{name}' not found.")
+
+    contacts = _vm.get_contacts_for_vendor(name)
+    approvals = _vm.get_vendor_approvals(name)
+
+    return VendorDetail(
+        id=vendor.id,
+        name=vendor.name,
+        processes=sorted(vendor.processes),
+        active=vendor.active,
+        rating=vendor.rating,
+        notes=vendor.notes,
+        address=vendor.address if isinstance(vendor.address, dict) else {},
+        contacts=[_contact_to_out(c) for c in contacts],
+        approvals=approvals,
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import LoginPage from './pages/LoginPage'
 import QueuePage from './pages/QueuePage'
+import VendorsPage from './pages/VendorsPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -48,15 +49,8 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
-            <Route
-              path="/queue"
-              element={
-                <PrivateRoute>
-                  <QueuePage />
-                </PrivateRoute>
-              }
-            />
-            {/* Redirect root to queue; login page handles unauthenticated users */}
+            <Route path="/queue" element={<PrivateRoute><QueuePage /></PrivateRoute>} />
+            <Route path="/vendors" element={<PrivateRoute><VendorsPage /></PrivateRoute>} />
             <Route path="/" element={<Navigate to="/queue" replace />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/api/vendors.ts
+++ b/frontend/src/api/vendors.ts
@@ -1,0 +1,49 @@
+import client from './client'
+
+export interface Contact {
+  name: string
+  first_name: string
+  last_name: string
+  email: string
+  phone: string
+  primary: boolean
+  state: string
+  website: string
+}
+
+export interface VendorSummary {
+  name: string
+  processes: string[]
+  active: boolean
+  rating: number
+  primary_contact: Contact | null
+}
+
+export interface VendorDetail extends VendorSummary {
+  id: string
+  notes: string
+  address: Record<string, string>
+  contacts: Contact[]
+  // { "Anodize": ["AMS 2468", ...] }
+  approvals: Record<string, string[]>
+}
+
+export async function fetchVendors(): Promise<VendorSummary[]> {
+  const { data } = await client.get<VendorSummary[]>('/vendors/')
+  return data
+}
+
+export async function fetchVendor(name: string): Promise<VendorDetail> {
+  const { data } = await client.get<VendorDetail>(`/vendors/${encodeURIComponent(name)}`)
+  return data
+}
+
+export async function searchVendorsBySpec(
+  process: string,
+  spec?: string,
+): Promise<VendorSummary[]> {
+  const params: Record<string, string> = { process }
+  if (spec) params.spec = spec
+  const { data } = await client.get<VendorSummary[]>('/vendors/search', { params })
+  return data
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,0 +1,55 @@
+/**
+ * Top navigation bar — shared across all pages.
+ *
+ * NavLink from react-router-dom applies an "active" class automatically
+ * when the current URL matches its `to` prop. We use that to highlight
+ * the current page without any manual state.
+ */
+
+import { NavLink } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+export default function Nav() {
+  const { user, clearAuth } = useAuth()
+
+  return (
+    <nav style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 4,
+      padding: '0 24px',
+      height: 48,
+      background: '#1a1a2e',
+      color: '#fff',
+    }}>
+      <span style={{ fontWeight: 700, marginRight: 16, fontSize: 15 }}>📬 RFQ Sender</span>
+
+      <NavLink to="/queue" style={navLinkStyle}>Queue</NavLink>
+      <NavLink to="/vendors" style={navLinkStyle}>Vendors</NavLink>
+
+      {/* push user info to the right */}
+      <span style={{ flex: 1 }} />
+      <span style={{ fontSize: 13, opacity: 0.75, marginRight: 12 }}>
+        {user?.name} · <code style={{ fontSize: 12 }}>{user?.role}</code>
+      </span>
+      <button
+        onClick={clearAuth}
+        style={{ background: 'transparent', border: '1px solid rgba(255,255,255,0.3)', color: '#fff', fontSize: 13 }}
+      >
+        Log Out
+      </button>
+    </nav>
+  )
+}
+
+function navLinkStyle({ isActive }: { isActive: boolean }) {
+  return {
+    color: isActive ? '#fff' : 'rgba(255,255,255,0.6)',
+    textDecoration: 'none',
+    padding: '4px 12px',
+    borderRadius: 4,
+    fontWeight: isActive ? 600 : 400,
+    background: isActive ? 'rgba(255,255,255,0.15)' : 'transparent',
+    fontSize: 14,
+  }
+}

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -18,9 +18,10 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { fetchQueue, removeQueueItem, type QueueItem } from '../api/queue'
 import { useAuth } from '../context/AuthContext'
 import AddToQueueForm from '../components/AddToQueueForm'
+import Nav from '../components/Nav'
 
 export default function QueuePage() {
-  const { user, clearAuth } = useAuth()
+  const { user } = useAuth()
   const queryClient = useQueryClient()
   const [showForm, setShowForm] = useState(false)
 
@@ -43,17 +44,10 @@ export default function QueuePage() {
   }
 
   return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Nav />
     <div style={{ padding: 24 }}>
-      {/* Header bar */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
-        <h1 style={{ margin: 0, fontSize: 20 }}>📋 RFQ Queue</h1>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          <span style={{ color: '#666' }}>
-            {user?.name} &mdash; <code style={{ fontSize: 12 }}>{user?.role}</code>
-          </span>
-          <button onClick={clearAuth}>Log Out</button>
-        </div>
-      </div>
+      <h1 style={{ margin: '0 0 20px', fontSize: 20 }}>📋 RFQ Queue</h1>
 
       {/* Add button — only visible to estimators and admins */}
       {(user?.role === 'estimator' || user?.role === 'admin') && (
@@ -144,6 +138,7 @@ export default function QueuePage() {
           </table>
         </>
       )}
+    </div>
     </div>
   )
 }

--- a/frontend/src/pages/VendorsPage.tsx
+++ b/frontend/src/pages/VendorsPage.tsx
@@ -1,0 +1,329 @@
+/**
+ * Vendors page — two tabs:
+ *   "Directory"    — search the vendor list, click one to see detail
+ *   "Find by Spec" — pick process + spec, see which vendors are approved
+ *
+ * New TanStack Query pattern introduced here: "dependent queries."
+ * The vendor detail query only runs when a vendor has been selected
+ * (enabled: !!selectedVendor). Same idea as the spec dropdown in AddToQueueForm
+ * — don't fetch until you have the input you need.
+ */
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Nav from '../components/Nav'
+import {
+  fetchVendors,
+  fetchVendor,
+  searchVendorsBySpec,
+  type VendorSummary,
+  type VendorDetail,
+  type Contact,
+} from '../api/vendors'
+import { fetchProcesses, fetchSpecsForProcess } from '../api/queue'
+
+type Tab = 'directory' | 'find-by-spec'
+type DetailTab = 'contacts' | 'processes' | 'approvals'
+
+export default function VendorsPage() {
+  const [tab, setTab] = useState<Tab>('directory')
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Nav />
+      <div style={{ padding: 24 }}>
+        <h1 style={{ margin: '0 0 16px' }}>Vendors</h1>
+
+        {/* Tab switcher */}
+        <div style={{ display: 'flex', gap: 4, marginBottom: 20, borderBottom: '2px solid #e0e0e0' }}>
+          {(['directory', 'find-by-spec'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              style={{
+                border: 'none',
+                borderBottom: tab === t ? '2px solid #1a73e8' : '2px solid transparent',
+                borderRadius: 0,
+                background: 'transparent',
+                padding: '8px 16px',
+                fontWeight: tab === t ? 600 : 400,
+                color: tab === t ? '#1a73e8' : '#444',
+                marginBottom: -2,
+              }}
+            >
+              {t === 'directory' ? 'Vendor Directory' : 'Find by Spec'}
+            </button>
+          ))}
+        </div>
+
+        {tab === 'directory' && <DirectoryTab />}
+        {tab === 'find-by-spec' && <FindBySpecTab />}
+      </div>
+    </div>
+  )
+}
+
+// ─── Directory tab ────────────────────────────────────────────────────────────
+
+function DirectoryTab() {
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const { data: vendors = [], isLoading } = useQuery({
+    queryKey: ['vendors'],
+    queryFn: fetchVendors,
+  })
+
+  // Only fetches when a vendor is selected — avoids loading all detail upfront
+  const { data: detail, isLoading: detailLoading } = useQuery({
+    queryKey: ['vendor', selected],
+    queryFn: () => fetchVendor(selected!),
+    enabled: !!selected,
+  })
+
+  const filtered = vendors.filter((v) =>
+    v.name.toLowerCase().includes(search.toLowerCase()) ||
+    v.processes.some((p) => p.toLowerCase().includes(search.toLowerCase()))
+  )
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '280px 1fr', gap: 20 }}>
+      {/* Left: vendor list */}
+      <div>
+        <input
+          placeholder="Search vendors or processes…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ marginBottom: 12 }}
+        />
+        {isLoading && <p style={{ color: '#666', fontSize: 13 }}>Loading…</p>}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {filtered.map((v) => (
+            <button
+              key={v.name}
+              onClick={() => setSelected(v.name)}
+              style={{
+                textAlign: 'left',
+                padding: '8px 10px',
+                border: '1px solid',
+                borderColor: selected === v.name ? '#1a73e8' : '#e0e0e0',
+                borderRadius: 4,
+                background: selected === v.name ? '#e8f0fe' : '#fff',
+                color: v.active ? '#1a1a1a' : '#999',
+                fontSize: 13,
+              }}
+            >
+              <div style={{ fontWeight: 500 }}>{v.name}</div>
+              <div style={{ fontSize: 11, color: '#666', marginTop: 2 }}>
+                {v.processes.slice(0, 3).join(' · ')}
+                {v.processes.length > 3 && ` +${v.processes.length - 3}`}
+              </div>
+            </button>
+          ))}
+          {!isLoading && filtered.length === 0 && (
+            <p style={{ color: '#666', fontSize: 13 }}>No vendors match.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Right: detail panel */}
+      <div>
+        {!selected && (
+          <div style={{ color: '#666', paddingTop: 40, textAlign: 'center' }}>
+            Select a vendor to view details.
+          </div>
+        )}
+        {selected && detailLoading && <p>Loading…</p>}
+        {selected && detail && <VendorDetailPanel detail={detail} />}
+      </div>
+    </div>
+  )
+}
+
+function VendorDetailPanel({ detail }: { detail: VendorDetail }) {
+  const [tab, setTab] = useState<DetailTab>('contacts')
+
+  const tabStyle = (t: DetailTab) => ({
+    border: 'none',
+    borderBottom: tab === t ? '2px solid #1a73e8' : '2px solid transparent',
+    borderRadius: 0,
+    background: 'transparent',
+    padding: '6px 14px',
+    fontWeight: tab === t ? 600 : 400,
+    color: tab === t ? '#1a73e8' : '#444',
+    marginBottom: -2,
+    fontSize: 13,
+    cursor: 'pointer',
+  })
+
+  const address = Object.values(detail.address).filter(Boolean).join(', ')
+
+  return (
+    <div style={{ background: '#fff', border: '1px solid #e0e0e0', borderRadius: 6, padding: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <h2 style={{ margin: '0 0 4px' }}>{detail.name}</h2>
+          {address && <p style={{ margin: '0 0 4px', color: '#666', fontSize: 13 }}>{address}</p>}
+          {!detail.active && <span style={{ fontSize: 12, color: '#d93025' }}>Inactive</span>}
+        </div>
+        {detail.rating > 0 && (
+          <span style={{ fontSize: 13, color: '#e37400' }}>
+            {'★'.repeat(detail.rating)}{'☆'.repeat(5 - detail.rating)}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', gap: 4, margin: '16px 0 0', borderBottom: '2px solid #e0e0e0' }}>
+        <button style={tabStyle('contacts')} onClick={() => setTab('contacts')}>Contacts</button>
+        <button style={tabStyle('processes')} onClick={() => setTab('processes')}>Processes</button>
+        <button style={tabStyle('approvals')} onClick={() => setTab('approvals')}>Approved Specs</button>
+      </div>
+
+      <div style={{ paddingTop: 16 }}>
+        {tab === 'contacts' && <ContactsTab contacts={detail.contacts} />}
+        {tab === 'processes' && <ProcessesTab processes={detail.processes} />}
+        {tab === 'approvals' && <ApprovalsTab approvals={detail.approvals} />}
+      </div>
+    </div>
+  )
+}
+
+function ContactsTab({ contacts }: { contacts: Contact[] }) {
+  if (contacts.length === 0) return <p style={{ color: '#666' }}>No contacts on file.</p>
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12 }}>
+      {contacts.map((c, i) => (
+        <div key={i} style={{ border: '1px solid #e0e0e0', borderRadius: 6, padding: 12 }}>
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>
+            {c.name || `${c.first_name} ${c.last_name}`.trim()}
+            {c.primary && (
+              <span style={{ marginLeft: 6, fontSize: 11, background: '#e8f0fe', color: '#1a73e8', padding: '1px 6px', borderRadius: 10 }}>
+                Primary
+              </span>
+            )}
+          </div>
+          {c.email && <div style={{ fontSize: 13 }}><a href={`mailto:${c.email}`}>{c.email}</a></div>}
+          {c.phone && <div style={{ fontSize: 13, color: '#666' }}>{c.phone}</div>}
+          {c.state && <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>{c.state}</div>}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ProcessesTab({ processes }: { processes: string[] }) {
+  if (processes.length === 0) return <p style={{ color: '#666' }}>No processes listed.</p>
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      {processes.map((p) => (
+        <span key={p} style={{ background: '#f1f3f4', padding: '4px 10px', borderRadius: 14, fontSize: 13 }}>
+          {p}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function ApprovalsTab({ approvals }: { approvals: Record<string, string[]> }) {
+  const processes = Object.keys(approvals).sort()
+  if (processes.length === 0) return <p style={{ color: '#666' }}>No approved specs on file.</p>
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {processes.map((process) => (
+        <div key={process}>
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>{process}</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {approvals[process].map((spec) => (
+              <span key={spec} style={{ background: '#e6f4ea', color: '#137333', padding: '3px 10px', borderRadius: 12, fontSize: 12 }}>
+                {spec}
+              </span>
+            ))}
+            {approvals[process].length === 0 && (
+              <span style={{ color: '#999', fontSize: 13 }}>None listed</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Find by Spec tab ─────────────────────────────────────────────────────────
+
+function FindBySpecTab() {
+  const [selectedProcess, setSelectedProcess] = useState('')
+  const [selectedSpec, setSelectedSpec] = useState('')
+
+  const { data: processes = [] } = useQuery({
+    queryKey: ['processes'],
+    queryFn: fetchProcesses,
+  })
+
+  const { data: specs = [] } = useQuery({
+    queryKey: ['specs', selectedProcess],
+    queryFn: () => fetchSpecsForProcess(selectedProcess),
+    enabled: !!selectedProcess,
+  })
+
+  // Only searches when both process and spec are chosen
+  const { data: results, isLoading: searching, isFetching } = useQuery({
+    queryKey: ['vendors-by-spec', selectedProcess, selectedSpec],
+    queryFn: () => searchVendorsBySpec(selectedProcess, selectedSpec),
+    enabled: !!selectedProcess && !!selectedSpec,
+  })
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 20 }}>
+        <div>
+          <label>Process</label>
+          <select
+            value={selectedProcess}
+            onChange={(e) => { setSelectedProcess(e.target.value); setSelectedSpec('') }}
+          >
+            <option value="">Select process…</option>
+            {processes.map((p) => <option key={p} value={p}>{p}</option>)}
+          </select>
+        </div>
+        <div>
+          <label>Specification</label>
+          <select
+            value={selectedSpec}
+            onChange={(e) => setSelectedSpec(e.target.value)}
+            disabled={!selectedProcess}
+          >
+            <option value="">{selectedProcess ? 'Select spec…' : 'Choose process first'}</option>
+            {specs.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {/* Results auto-appear once both dropdowns are set — no Search button needed */}
+      {(searching || isFetching) && <p style={{ color: '#666' }}>Searching…</p>}
+
+      {results && !isFetching && (
+        <>
+          <p style={{ color: '#666', marginBottom: 12 }}>
+            {results.length === 0
+              ? `No vendors approved for ${selectedSpec} (${selectedProcess}).`
+              : `${results.length} vendor${results.length !== 1 ? 's' : ''} approved for ${selectedSpec}`}
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {results.map((v: VendorSummary) => (
+              <div key={v.name} style={{ background: '#fff', border: '1px solid #e0e0e0', borderRadius: 6, padding: 14 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>{v.name}</div>
+                {v.primary_contact && (
+                  <div style={{ fontSize: 13, color: '#444' }}>
+                    {v.primary_contact.name && <span>{v.primary_contact.name} · </span>}
+                    {v.primary_contact.email && <a href={`mailto:${v.primary_contact.email}`}>{v.primary_contact.email}</a>}
+                    {v.primary_contact.phone && <span> · {v.primary_contact.phone}</span>}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
- api/routers/vendors.py: GET /vendors/, GET /vendors/search, GET /vendors/{name}
- api/models/vendor.py: ContactOut, VendorSummary, VendorDetail Pydantic models
- frontend/src/pages/VendorsPage.tsx: two-tab page (Vendor Directory + Find by Spec)
  - Directory: searchable list with click-to-expand detail panel (contacts, processes, approved specs)
  - Find by Spec: dependent process/spec dropdowns auto-query matching vendors
- frontend/src/components/Nav.tsx: top nav bar with active-link highlighting, shared across pages
- App.tsx: adds /vendors route, removes per-page logout (Nav handles it)
- QueuePage.tsx: uses Nav component instead of inline header

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes